### PR TITLE
Update specification_service.go to not fail sometimes

### DIFF
--- a/src/husniadil/gsm/service/specification/specification_service.go
+++ b/src/husniadil/gsm/service/specification/specification_service.go
@@ -38,7 +38,7 @@ func getDeviceName(s *goquery.Selection) string {
 
 func getImageURL(s *goquery.Selection) (imageURL string, err error) {
 	imageURL, imageURLExists := s.Find(".specs-photo-main").
-		Find("a").Find("img").Attr("src")
+		Find("img").Attr("src")
 
 	if !imageURLExists {
 		err = errors.New("Cannot resolve image url")


### PR DESCRIPTION
Previously it was assumed that every device image was contained in an <a> element. However, that's sometimes not the case ([two](https://www.gsmarena.com/acer_iconia_one_8_b1_820-7217.php) [times](https://www.gsmarena.com/acer_betouch_t500-3587.php) in the first brand alone).

This file change adds support for those devices by searching for just <img> elements instead of <img> elements inside of <a> elements.